### PR TITLE
Fix ansible.cfg delimiter

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,2 +1,2 @@
 [defaults]
-interpreter_python: auto
+interpreter_python = auto


### PR DESCRIPTION
Cfg uses `=` and not `:`.